### PR TITLE
Save-as enable fix

### DIFF
--- a/LaSSI/MainForm.eto.cs
+++ b/LaSSI/MainForm.eto.cs
@@ -167,8 +167,9 @@ namespace LaSSI
       }
       private void EnableSaveAs()
       {
-         var baz = ((SubMenuItem)Menu.Items.First(c => c.Text == "&File")).Items.Select(m => m.Command as Command).First(s => s != null && s.Tag == (object)"SaveFileAsCommand");
-         if(baz is not null) baz.Enabled = true;
+         var SaveAsCommand = ((SubMenuItem)Menu.Items.First(menuItem => menuItem.Text == "&File")).Items.Select(submenuItem 
+            => submenuItem.Command as Command).First(command => command != null && command.Tag == (object)"SaveFileAsCommand");
+         if(SaveAsCommand is not null) SaveAsCommand.Enabled = true;
       }
       #endregion command handlers
       #endregion commands


### PR DESCRIPTION
Replaced array accessors with LINQ to find the SaveAsCommand. Prevents exception on Windows (and is better practice).