### PR TITLE
Finished apply/revert, DERELICTS

### DIFF
--- a/LaSSI/CollectionChange.cs
+++ b/LaSSI/CollectionChange.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using Eto.Forms;
+
+namespace LaSSI
+{
+   public class CollectionChange
+   {
+      public enum ActionType
+      {
+         None,
+         Change,
+         Addition,
+         Deletion
+      }
+      public Oncler Data;
+      public ActionType Action;
+      public CollectionChange(ActionType action, Oncler data)
+      {
+         Action = action;
+         Data = data;
+      }
+
+      internal static bool ListContainsOncler(List<CollectionChange> changes, string key)
+      {
+         foreach (var change in changes)
+         {
+            if (change.Data.Key.Equals(key))
+            {
+               return true;
+            }
+         }
+         return false;
+      }
+
+      internal static ActionType GetOnclersChangeAction(List<CollectionChange> changes, string key)
+      {
+         if (CollectionChange.ListContainsOncler(changes, key))
+         {
+            return FindInList(changes, key).Action;
+         }
+         else
+         {
+            return ActionType.None;
+         }
+      }
+
+      internal static void UpdateChangeValue(List<CollectionChange> changes, Oncler values)
+      {
+         if (CollectionChange.ListContainsOncler(changes, values.Key))
+         {
+            FindInList(changes, values.Key).Data.Value = values.Value;
+         }
+      }
+
+      internal static CollectionChange FindInList(List<CollectionChange> changes, string key)
+      {
+         return changes.Find(x => x.Data.Key == key);
+      }
+
+      public static void AddChange(List<CollectionChange> changes, Oncler newChange, CollectionChange.ActionType action)
+      {
+         if (!CollectionChange.ListContainsOncler(changes, newChange.Key))
+         {
+            changes.Add(new CollectionChange(action, newChange));
+            return;
+         }
+         switch (action)
+         {
+            case ActionType.Addition:
+               {
+                  if (CollectionChange.GetOnclersChangeAction(changes, newChange.Key) == CollectionChange.ActionType.Deletion)
+                  {
+                     changes.Remove(CollectionChange.FindInList(changes, newChange.Key));
+                  }
+                  break;
+               }
+            case ActionType.Deletion:
+               {
+                  bool shouldAdd = CollectionChange.GetOnclersChangeAction(changes, newChange.Key) == ActionType.Change;
+                  changes.Remove(CollectionChange.FindInList(changes, newChange.Key));
+                  if (shouldAdd) changes.Add(new CollectionChange(action, newChange));
+                  break;
+               }
+            case ActionType.Change:
+               {
+                  ActionType prevAction = CollectionChange.GetOnclersChangeAction(changes, newChange.Key);
+                  if (prevAction == ActionType.Change || prevAction == ActionType.Addition)
+                  {
+                     //update value
+                     CollectionChange.FindInList(changes, newChange.Key).Data.Value = newChange.Value;
+                  }
+                  break;
+               }
+         }
+
+
+         //ADD
+         // check if already in changes list
+         // if del, remove del and continue
+
+
+         //DEL
+
+         //check if already in changes list
+         //if chg, remove and then add del op
+         //if add, remove add op and continue
+         //List<CollectionChange> changes = ((DetailsLayout)GetPanel2DetailsLayout().Content).Changes;
+
+         //CHG
+
+         //check if already in list
+         //if rem, return
+         //if add, update value
+         //if change, update value
+         //otherwise, add to list
+      }
+      //public static bool CheckForChange(List<CollectionChange> changes, Oncler newChange)
+      //{
+
+
+      //   return false;
+      //}
+   }
+}
+

--- a/LaSSI/DataPanel.cs
+++ b/LaSSI/DataPanel.cs
@@ -7,28 +7,38 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Eto;
 
 namespace LaSSI
 {
    public class DataPanel : Panel
    {
+      public enum DerelictsCleaningMode
+      {
+         CurrentSystem,
+         SectorWide,
+         SpecificSystem
+      }
+
       private Dictionary<TreeGridItem, DetailsLayout> DetailPanelsCache = new();
       private Size DetailsPanelInitialSize = new(0, 0);
       private readonly List<InventoryGridItem>? InventoryMasterList;
       private Node? Root { get; set; }
       private readonly int ParentWidth = 0;
-      private readonly Button Apply = new(ApplyButton_Click)
+      private PreviousEntry? CurrentValues;
+      private readonly Button Apply = new()
       {
          Text = "Apply",
          ID = "DetailsApplyButton",
          Enabled = false
       };
-      private readonly Button Revert = new(RevertButton_Click)
+      private readonly Button Revert = new()
       {
          Text = "Revert",
          ID = "DetailsRevertButton",
          Enabled = false
       };
+      private DetailsLayout? CurrentDetails;
       public DataPanel()
       {
 
@@ -50,6 +60,8 @@ namespace LaSSI
       }
       private TableLayout InitPrimaryPanel() // any particular reason this is a TableLayout?
       {
+         Apply.Click += ApplyButton_Click;
+         Revert.Click += RevertButton_Click;
          Splitter sp = CreateSplitter();
 
          //TreeGridView treeView = CreateTreeView();
@@ -70,8 +82,8 @@ namespace LaSSI
          {
             Tag = "DataTreeView",
             ID = "DataTreeView",
-            AllowEmptySelection = true,
-            AllowMultipleSelection = true
+            //AllowEmptySelection = true,
+            //AllowMultipleSelection = true
          };
          treeView.SelectedItemChanged += TreeView_SelectedItemChanged;
          return treeView;
@@ -98,10 +110,6 @@ namespace LaSSI
          {
             ID = "Panel2DetailsLayout"
          };
-         //Panel2Layout.Add(DetailScrollable);
-         //Panel2Layout.Rows
-         //Panel2Layout.AddSeparateRow(new Label { Text = "here!" });
-         //Panel2Layout.AddSpace(); // neccessary?
          Panel2Layout.AddSeparateRow(CreateApplyRevertButtonsLayout());
          Panel2Layout.AddSeparateRow(Panel2DetailsLayout);
          return Panel2Layout;
@@ -127,34 +135,35 @@ namespace LaSSI
          if (InventoryMasterList is not null)
          {
             RemainingItems = new ObservableCollection<InventoryGridItem>(InventoryMasterList);
-            foreach (var value in item.Values)
+            var value = item.Values[1];
+            if (value is OrderedDictionary dictionary && dictionary.Count != 0)
             {
-               if (value is Dictionary<string, string> dictionary && dictionary.Count != 0)
+               foreach (DictionaryEntry entry in dictionary)
                {
-                  foreach (var entry in dictionary)
+                  try
                   {
-                     try
-                     {
-                        ShuttleItems(RemainingItems, InStock, entry);
-                     }
-                     catch
-                     {
-                        Debug.WriteLine($"Item not found in master list: {entry.Key}");
-                     }
+                     ShuttleItems(RemainingItems, InStock, entry);
+                  }
+                  catch
+                  {
+                     Debug.WriteLine($"Item not found in master list: {entry.Key}");
                   }
                }
             }
          }
 
-         return new ListBuilder(RemainingItems, new List<string> { "Remaining items" }, InStock, new List<string> { "In stock", "Count" });
+         ListBuilder lb = new ListBuilder(RemainingItems, new List<string> { "Remaining items" }, InStock, new List<string> { "In stock", "Count" });
+         lb.RightGridUpdated += RightGrid_Updated;
+         lb.ID = "ListBuilder";
+         return lb;
       }
       private void ShuttleItems(ObservableCollection<InventoryGridItem> RemainingItems
          , ObservableCollection<InventoryGridItem> InStock
-         , KeyValuePair<string, string> entry)
+         , DictionaryEntry entry)
       {
-         InventoryGridItem InvItem = RemainingItems.Where(x => x.Name == entry.Key).First();
+         InventoryGridItem InvItem = RemainingItems.Where(x => x.Name == entry.Key.ToString()).First();
          RemainingItems.Remove(InvItem);
-         InvItem.Count = int.Parse(entry.Value);
+         InvItem.Count = int.Parse(entry.Value!.ToString()!);
          InStock.Add(InvItem);
       }
       private DetailsLayout CreateDetailsLayout(TreeGridItem item)
@@ -164,13 +173,15 @@ namespace LaSSI
             //Padding = new Padding(5, 0),
             Spacing = new Size(0, 5)
          };
-
          detailsLayout.Add(GetNodePathLabel(item));
          switch (item.Tag)
          {
             case "OurStock":
                {
                   detailsLayout.Add(CreateListBuilder(item));
+                  ListBuilder lb = (ListBuilder)detailsLayout.Children.First(x => x.ID == "ListBuilder");
+                  lb.Enabled = false;
+                  lb.ContextMenu = new ContextMenu(new Command { MenuText = "Disabled/unfinished" });
                   break;
                }
             case "TheirStock":
@@ -198,6 +209,81 @@ namespace LaSSI
 
          return detailsLayout;
       }
+
+      public void CleanDerelicts(DerelictsCleaningMode mode)  // todo: this whole thing kinda sucks. Works though!
+      {
+         TreeGridView tree = GetTreeGridView();
+         TreeGridItemCollection items = (TreeGridItemCollection)tree.DataStore;
+         List<TreeGridItem> toRemove = new List<TreeGridItem>();
+         TreeGridItem root = (TreeGridItem)items.First();
+         TreeGridItemCollection sysArchChildren = ((TreeGridItem)((TreeGridItem)root[1])[2]).Children;
+         switch (mode)
+         {
+            case DerelictsCleaningMode.CurrentSystem:
+               {
+                  toRemove = CompileDerelictList(root.Children);
+                  foreach (var v in toRemove)
+                  {
+                     root.Children.Remove(v);
+                  }
+                  break;
+               }
+            case DerelictsCleaningMode.SectorWide:
+               {
+
+                  foreach (TreeGridItem sys in sysArchChildren)
+                  {
+                     toRemove = CompileDerelictList(sys.Children);
+                     foreach (var v in toRemove)
+                     {
+                        sys.Children.Remove(v);
+                     }
+                  }
+
+                  toRemove = CompileDerelictList(root.Children);
+                  foreach (var v in toRemove)
+                  {
+                     root.Children.Remove(v);
+                  }
+                  break;
+               }
+            case DerelictsCleaningMode.SpecificSystem:
+               {
+                  // I don't know what to do here
+                  break;
+               }
+         }
+
+
+         tree.DataStore = items;
+      }
+      private List<TreeGridItem> CompileDerelictList(TreeGridItemCollection items)
+      {
+         List<TreeGridItem> toRemove = new List<TreeGridItem>();
+         foreach (TreeGridItem item in items)
+         {
+            OrderedDictionary properties = (OrderedDictionary)item.Values[1];
+            if (/*properties.Contains((object)"Class")
+               && */properties.Contains((object)"Type"))
+            {
+               //var s = properties[(object)"Class"];
+               var t = properties[(object)"Type"];
+               if (/*s is not null && s.ToString() == "Ship" && */t is not null && t.ToString() == "Derelict")
+               {
+                  toRemove.Add(item);
+               }
+
+            }
+         }
+         return toRemove;
+      }
+      //private void RemoveDerelictNode(TreeGridItem node)
+      //{
+      //   if ()
+      //   {
+
+      //   }
+      //}
       private static string GetNodePath(TreeGridItem item)
       {
          string path = item.Values[0].ToString()!;
@@ -222,15 +308,20 @@ namespace LaSSI
       private GridView CreateDefaultFieldsGridView(TreeGridItem item)
       {
          OrderedDictionary vals = (OrderedDictionary)item.Values[1];
-         //Dictionary<string, string> dic = new Dictionary<string, string>();
-         IEnumerable<object> foo = vals.Cast<object>();
+         ObservableCollection<Oncler> bar = new ObservableCollection<Oncler>();
+         foreach (DictionaryEntry val in vals)
+         {
+            bar.Add(new Oncler(val));
+         }
          GridView defaultGridView = new()
          {
-            DataStore = foo,
+            DataStore = bar,
             AllowMultipleSelection = false,
             GridLines = GridLines.Both,
+            ID = "DefaultGridView"
 
          };
+         defaultGridView.ContextMenu = new ContextMenu(AddGridViewRow(), DeleteGridViewRow());
          //defaultGridView.
          defaultGridView.Columns.Add(new GridColumn
          {
@@ -239,7 +330,7 @@ namespace LaSSI
             {
                Binding = Binding.Property((DictionaryEntry i) => (string)i.Key)
             },
-            Editable = true,
+            Editable = false,
             //AutoSize = true,
             //Resizable = true
          });
@@ -255,8 +346,123 @@ namespace LaSSI
             //Resizable = true
          });
          defaultGridView.Shown += DefaultGridView_Shown;
+         defaultGridView.CellEditing += DefaultGridView_CellEditing;
+         defaultGridView.CellEdited += DefaultGridView_CellEdited;
+         //defaultGridView.KeyUp += DefaultGridView_KeyUp;
+         //defaultGridView.MouseDown += DefaultGridView_MouseDown;
+         bar.CollectionChanged += Bar_CollectionChanged;
          return defaultGridView;
       }
+      private Command AddGridViewRow()
+      {
+         var addNewRow = new Command { MenuText = "Add row", /*Shortcut = Application.Instance.CommonModifier | Keys.Equal*/ };
+         addNewRow.Executed += AddRow_Executed;
+         return addNewRow;
+      }
+      private Command DeleteGridViewRow()
+      {
+         var deleteRow = new Command { MenuText = "Delete row", /*Shortcut = Application.Instance.CommonModifier | Keys.Backspace*/ };
+         deleteRow.Executed += DeleteRow_Executed;
+         return deleteRow;
+      }
+
+      private void DeleteRow_Executed(object? sender, EventArgs e)
+      {
+         GridView grid = GetDefaultGridView();
+         if (grid.SelectedRow >= 0)
+         {
+            Oncler row = (Oncler)grid.SelectedItem;
+            CollectionChange.AddChange(((DetailsLayout)GetPanel2DetailsLayout().Content).Changes, row, CollectionChange.ActionType.Deletion);
+
+            ((ObservableCollection<Oncler>)grid.DataStore).Remove(row);
+         }
+      }
+
+      private void AddRow_Executed(object? sender, EventArgs e)
+      {
+         GridView grid = GetDefaultGridView();
+         ObservableCollection<Oncler> onclers = ((ObservableCollection<Oncler>)grid.DataStore);
+         int i = onclers.Count;
+
+         TextInputDialog dialog = new("New row", "Key");
+         dialog.ShowModal(this);
+         if (dialog.GetDialogResult() == DialogResult.Ok)
+         {
+            string newkey = dialog.GetInput();
+            bool alreadyInUse = false;
+            foreach (var f in onclers)
+            {
+               if (f.Key == newkey) alreadyInUse = true;
+            }
+            if (alreadyInUse)
+            {
+               MessageBox.Show("That key is already in use", MessageBoxButtons.OK, MessageBoxType.Error, MessageBoxDefaultButton.OK);
+            }
+            else
+            {
+               Oncler newRow = new(newkey);
+               CollectionChange.AddChange(((DetailsLayout)GetPanel2DetailsLayout().Content).Changes, newRow, CollectionChange.ActionType.Addition);
+               onclers.Add(newRow);
+               grid.SelectRow(i);
+               grid.BeginEdit(i, 1);
+            }
+         }
+      }
+      private GridView GetDefaultGridView()
+      {
+         return (GridView)((DetailsLayout)GetPanel2DetailsLayout().Content).FindChild("DefaultGridView");
+      }
+      private ListBuilder GetListBuilder()
+      {
+         return (ListBuilder)((DetailsLayout)GetPanel2DetailsLayout().Content).FindChild("ListBuilder");
+      }
+
+      private void Bar_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+      {
+         UpdateApplyRevertButtons(DetailsLayout.State.Modified);
+         // todo: register changes
+         //if (e != null)
+         //{
+         //   switch (e.Action)
+         //   {
+         //      case NotifyCollectionChangedAction.Add:
+         //         {
+         //            break;
+         //         }
+         //      case NotifyCollectionChangedAction.Remove:
+         //         {
+         //            break;
+         //         }
+         //      default:
+         //         {
+         //            break;
+         //         }
+         //   }
+         //}
+      }
+
+      //private void DefaultGridView_KeyUp(object? sender, KeyEventArgs e)
+      //{
+      //   Keys mod = e.Modifiers;
+      //   Keys key = e.Key;
+
+      //   // backspace = propmt
+      //   // common mod+backspace = no prompt
+      //   // delete = no prompt
+      //   Keys ModifiedBackspace = Application.Instance.CommonModifier | Keys.Backspace; // todo: this doesn't work
+      //   bool delete = e.KeyData == ModifiedBackspace || e.KeyData == Keys.Delete;
+      //   if (!delete && key.Equals(Keys.Backspace))
+      //   {
+      //      delete = MessageBox.Show(this.ParentWindow, "Delete this row?",
+      //         MessageBoxButtons.YesNo, MessageBoxType.Warning, MessageBoxDefaultButton.No) == DialogResult.Yes;
+      //   }
+      //   if (delete)
+      //   {
+      //      GridView view = (GridView)sender!;
+      //      ObservableCollection<Oncler> foo = (ObservableCollection<Oncler>)view.DataStore;
+      //      foo.RemoveAt(view.SelectedRow);
+      //   }
+      //}
 
       private static Label CreateDetailLabel(string text)
       {
@@ -391,19 +597,45 @@ namespace LaSSI
          };
       }
 
-      private void UpdateDetailsPanel(TreeGridItem item)
+      private void UpdateDetailsPanel(TreeGridItem item, bool clearPreexisting = false)
       {
+         if (clearPreexisting && DetailPanelsCache.ContainsKey(item))
+         {
+            DetailPanelsCache.Remove(item);
+         }
          DynamicLayout detailslayout = GetPanel2DetailsLayout();
          if (!DetailPanelsCache.ContainsKey(item))
          {
             DetailPanelsCache.Add(item, CreateDetailsLayout(item));
          }
-         //Panel2PrimeLayout.AddSeparateRow(DetailPanelsCache[item]);
-         //Label f = new Label { Text = $"{item.Tag}", Size = new Size { Height = 50, Width = 50 } };
          detailslayout.Content = DetailPanelsCache[item];
-         //UpdateApplyRevertButtons(DetailPanelsCache[item].Status);
-         //this.Invalidate();
+         UpdateApplyRevertButtons(DetailPanelsCache[item].Status);
       }
+      //private void UpdateTreeGridItemStatus(TreeGridItem item, NodeStatus status)
+      //{
+      //   item.Values[2] = status;
+      //   if (item.Parent is not null and TreeGridItem parent)
+      //   {
+      //      NodeStatus parentStatus = (NodeStatus)parent.Values[2];
+      //      if(status == NodeStatus.Default && parentStatus == NodeStatus.ChildEdited)
+      //      {
+      //         UpdateTreeGridItemStatus(parent, NodeStatus.Default);
+      //      }
+      //      else if () // just realized that this would clobber the ChildEdited status of a parent with a second child that's been edited
+      //         // screw it--colors are back on the backburner
+      //      {
+
+      //      }
+      //      switch((NodeStatus)parent.Values[2])
+      //      {
+      //         case NodeStatus.Default:
+      //            {
+      //               break;
+      //            }
+      //      }
+
+      //   }
+      //}
       private void UpdateApplyRevertButtons(DetailsLayout.State status)
       {
          switch (status)
@@ -420,8 +652,8 @@ namespace LaSSI
                }
             case DetailsLayout.State.Applied:
                {
-                  Apply.Enabled = false;
-                  Revert.Enabled = true; // todo: handle this case
+                  Apply.Enabled = Revert.Enabled = false;//todo: if the user wants to undo an applied change, they need to reload the node
+                                                         //todo: add a way to reload the node
                   break;
                }
          }
@@ -433,8 +665,13 @@ namespace LaSSI
       }
       private DynamicLayout GetPanel2DetailsLayout()
       {
-         return (DynamicLayout)this.Children.Where<Control>(x => x.ID == "Panel2DetailsLayout").First();
-         // pretty sure this blows up if the prime layout isn't found
+         return (DynamicLayout)this.FindChild("Panel2DetailsLayout");
+         // pretty sure this blows up if the details layout isn't found
+      }
+      private TreeGridView GetTreeGridView()
+      {
+         return (TreeGridView)this.Children.Where<Control>(x => x.ID == "DataTreeView").First();
+         // pretty sure this blows up if the data tree isn't found
       }
 
       public void Rebuild(Node root)
@@ -446,9 +683,9 @@ namespace LaSSI
       }
       private void ClearDetails()
       {
-         DynamicLayout s = GetPanel2PrimeLayout();
-         //s.Rows[0] = null;
-         //UpdateApplyRevertButtons(DetailsLayout.State.Unmodified); // todo: turn this back on
+         DynamicLayout s = GetPanel2DetailsLayout();
+         s.Content = null;
+         UpdateApplyRevertButtons(DetailsLayout.State.Unmodified);
       }
       private void RebuildTreeView(Node root)
       {
@@ -462,7 +699,7 @@ namespace LaSSI
                DataCell = new TextBoxCell(0)
             });
          }
-         x.CellFormatting += X_CellFormatting;
+         //x.CellFormatting += X_CellFormatting;
       }
       private TreeGridItemCollection SaveFile2TreeGridItems(Node root)
       {
@@ -477,7 +714,7 @@ namespace LaSSI
       {
          if (!node.HasChildren())
          {
-            return new TreeGridItem(node.Name, node.Properties)
+            return new TreeGridItem(node.Name, node.Properties, NodeStatus.Default)
             {
                Tag = node.Name
             };
@@ -489,7 +726,7 @@ namespace LaSSI
             {
                childItems.Add(WalkNodeTree(child));
             }
-            return new TreeGridItem(childItems, node.Name, node.Properties)
+            return new TreeGridItem(childItems, node.Name, node.Properties, NodeStatus.Default)
             {
                Tag = node.Name
             };
@@ -516,8 +753,128 @@ namespace LaSSI
          }
          return control.Size;
       }
+      private void DetailsModified()
+      {
+         Apply.Enabled = Revert.Enabled = true;
+         //GridView grid = (GridView)sender;
 
+         ((DetailsLayout)GetPanel2DetailsLayout().Content).Status = DetailsLayout.State.Modified;
+         //return DetailsLayout.State.Modified;
+      }
+      private void DetailsUnmodified()
+      {
+         Apply.Enabled = Revert.Enabled = false;
+         //GridView grid = (GridView)sender;
+
+         ((DetailsLayout)GetPanel2DetailsLayout().Content).Status = DetailsLayout.State.Unmodified;
+      }
+      private void DetailsApplied()
+      {
+         Apply.Enabled = Revert.Enabled = false;
+         //GridView grid = (GridView)sender;
+
+         ((DetailsLayout)GetPanel2DetailsLayout().Content).Status = DetailsLayout.State.Applied;
+      }
+      public bool ChangesAreUnapplied()
+      {
+         foreach (var v in DetailPanelsCache)
+         {
+            if (((DetailsLayout)v.Value).Status == DetailsLayout.State.Modified)
+            {
+               return true;
+            }
+         }
+         return false;
+      }
+      public bool ReadyForSave()
+      {
+         if (ChangesAreUnapplied())
+         {
+            DialogResult result = MessageBox.Show($"There are unapplied changes!{Environment.NewLine}Apply before saving?"
+               , MessageBoxButtons.YesNoCancel, MessageBoxType.Warning, MessageBoxDefaultButton.Yes);
+            switch (result)
+            {
+               case DialogResult.Yes:
+                  {
+                     ApplyAllChanges();
+                     return true;
+                  }
+               case DialogResult.No:
+                  {
+                     return true;
+                  }
+               case DialogResult.Cancel:
+                  {
+                     return false;
+                  }
+               default:
+                  {
+                     return false;
+                  }
+            }
+         }
+         else
+         {
+            return true;
+         }
+      }
+
+      private void ApplyAllChanges()
+      {
+         foreach (var v in DetailPanelsCache)
+         {
+            if (((DetailsLayout)v.Value).Status == DetailsLayout.State.Modified)
+            {
+               ApplyChange(v.Key, v.Value.Children.First(x => x.ID == "DefaultGridView" || x.ID == "ListBuilder")); // todo: _really_ need to genericize this!
+               v.Value.Status = DetailsLayout.State.Applied;
+            }
+         }
+         UpdateApplyRevertButtons(DetailsLayout.State.Applied);
+      }
       #region event handlers
+
+      private void DefaultGridView_CellEdited(object? sender, GridViewCellEventArgs e)
+      {
+         //DetailsLayout.State state = DetailsLayout.State.Unmodified;
+         if (CurrentValues is not null && CurrentValues.IsChanged(((Oncler)e.Item).ToDictionaryEntry())) // todo: revise this so manually setting changes back runs Unmodified!
+         {
+
+            //Changes.Add(new CollectionChange(CollectionChange.ActionType.Change, CurrentValues.deV));
+            //state = DetailsModified();
+            DetailsModified();
+         }
+         else
+         {
+            DetailsUnmodified();
+         }
+         //if (state == DetailsLayout.State.Modified)
+         //{
+         //   TreeGridView tree = GetTreeGridView();
+         //   UpdateTreeGridItemStatus((TreeGridItem)tree.SelectedItem, NodeStatus.Edited);
+         //   //tree.TriggerStyleChanged();
+         //}
+      }
+
+      private void DefaultGridView_CellEditing(object? sender, GridViewCellEventArgs e)
+      {
+         CurrentValues = new PreviousEntry(e.Column, e.Row, ((Oncler)e.Item).ToDictionaryEntry());
+         //Oncler values = ((Oncler)e.Item);
+         //if (CollectionChange.ListContainsOncler(Changes, values))
+         //{
+         //   CollectionChange.ActionType action = CollectionChange.GetOnclersChangeAction(Changes, values);
+         //   if (action == CollectionChange.ActionType.Change
+         //      || action == CollectionChange.ActionType.Addition)
+         //   {
+         //      CollectionChange.UpdateChangeValue(Changes, values);
+         //   }
+         //}
+         //else
+         //{
+         //   Changes.Add(new CollectionChange(CollectionChange.ActionType.Change, values));
+         //}
+
+      }
+
       private void TreeView_SelectedItemChanged(object? sender, EventArgs e)
       {
          if (sender is not null and TreeGridView)
@@ -538,9 +895,10 @@ namespace LaSSI
       private void X_CellFormatting(object? sender, GridCellFormatEventArgs e)
       {
          //e.BackgroundColor = e.Row % 2 == 0 ? Colors.Blue : Colors.LightBlue;
-         if (e.Item is not null and TreeGridItem item && item.Values.Length > 2)
+         if (e.Item is not null and TreeGridItem item && item.Values.Length > 2
+            && item == ((TreeGridView)sender!).SelectedItem && (NodeStatus)item.Values[2] != NodeStatus.Default)
          {
-            Color newColor = Colors.White;
+            Color? newColor = null;
             NodeStatus s = (NodeStatus)item.Values[2];
             switch (s)
             {
@@ -560,7 +918,11 @@ namespace LaSSI
                      break;
                   }
             }
-            e.BackgroundColor = newColor;
+            if (newColor is not null)
+            {
+               e.BackgroundColor = (Color)newColor;
+            }
+
          }
 
          //Colors.
@@ -577,17 +939,130 @@ namespace LaSSI
          }
       }
 
-      private static void RevertButton_Click(object? sender, EventArgs e)
+      private void RevertButton_Click(object? sender, EventArgs e)
       {
-         MessageBox.Show("Revert button clicked");
-         // remember to handle the case in which the node is applied already
+         TreeGridItem item = GetSelectedTreeGridItem();
+         UpdateDetailsPanel(item, true);
       }
 
-      private static void ApplyButton_Click(object? sender, EventArgs e)
+      private void ApplyButton_Click(object? sender, EventArgs e) // todo: generic way to get ahold of the current details-details panel (damn, I've really screwed up the nomenclature...)
       {
-         MessageBox.Show("Apply button clicked");
+         //MessageBox.Show("Apply button clicked");
+         // oh god here we go
+         TreeGridItem item = GetSelectedTreeGridItem();
+         //GridView gridview = GetDefaultGridView();
+         //ListBuilder listBuilder = GetListBuilder();
+         Control detailControl = GetPanel2DetailsLayout().Content;
+         // find differences between the gridview and the item, update the item
+         //I'm so nervous. I don't know why. Is it because I've been waiting for this moment for so long?
+         if ((detailControl is Scrollable s && s.Content is GridView gridView))
+         {
+            detailControl = gridView;
+         }
+         ApplyChange(item, detailControl);
+
+         UpdateApplyRevertButtons(DetailsLayout.State.Applied);
+         DetailsApplied();
+      }
+
+      private static void ApplyChange(TreeGridItem item, Control detailControl)
+      {
+         OrderedDictionary itemDictionary = new OrderedDictionary();
+
+         if (detailControl is not null)
+         {
+            if (detailControl is GridView gridView)
+            {
+               ObservableCollection<Oncler> gridCollection = (ObservableCollection<Oncler>)gridView.DataStore;
+               foreach (var oncler in gridCollection)
+               {
+                  itemDictionary.Add(oncler.Key, oncler.Value);
+               }
+            }
+            else if (detailControl is ListBuilder lb)
+            {
+               ObservableCollection<InventoryGridItem> listItems = lb.GetRightList();
+               foreach (var entry in listItems)
+               {
+                  itemDictionary.Add(entry.Name, entry.Count);
+               }
+            }
+            item.Values[1] = itemDictionary;
+         }
+      }
+
+      private TreeGridItem GetSelectedTreeGridItem()
+      {
+         return (TreeGridItem)GetTreeGridView().SelectedItem;
+      }
+      private void RightGrid_Updated(object? sender, EventArgs? e)
+      {
+         if (sender is not null and ObservableCollection<InventoryGridItem> RightList)
+         {
+            if (GetTreeGridView() is not null and TreeGridView treeGrid)
+            {
+               if (treeGrid.SelectedItem is TreeGridItem item && item.Values[1] is OrderedDictionary initialData)
+               {
+                  Dictionary<string, string> currentData = new Dictionary<string, string>();
+                  foreach (var entry in RightList)
+                  {
+                     currentData.Add(entry.Name, entry.Count.ToString());
+                  }
+                  var dict = initialData.Cast<DictionaryEntry>().ToDictionary(k => (string)k.Key, v => v.Value!.ToString());
+                  if (ListBuilder.IsGridModified(dict!, currentData))
+                  {
+                     DetailsModified();
+                  }
+                  else
+                  {
+                     DetailsUnmodified();
+                  }
+               }
+            }
+         }
       }
       #endregion event handlers
+   }
+
+
+   public class PreviousEntry // todo: revise this
+   {
+      public int Column { get; set; }
+      public int Row { get; set; }
+      public string? Value { get; set; }
+      DictionaryEntry? deValue { get; set; }
+      public PreviousEntry(int col, int row, string value)
+      {
+         Column = col;
+         Row = row;
+         Value = value;
+      }
+      public PreviousEntry(int col, int row, DictionaryEntry entry)
+      {
+         Column = col;
+         Row = row;
+         deValue = entry;
+      }
+      public bool IsChanged(string value) // these don't work as intended--can't recognize when the value is set back to the initial value
+      {
+         return !this.Value.Equals(value, StringComparison.CurrentCultureIgnoreCase);
+      }
+      public bool IsChanged(DictionaryEntry value) // these don't work as intended--can't recognize when the value is set back to the initial value
+      {
+         string x = string.Empty, y = string.Empty;
+         if (Column == 0)
+         {
+            x = deValue.Value.Key.ToString();
+            y = value.Key.ToString();
+         }
+         else if (Column == 1)
+         {
+            x = deValue.Value.Value.ToString();
+            y = value.Value.ToString();
+         }
+
+         return x != y;
+      }
    }
 }
 

--- a/LaSSI/DetailsLayout.cs
+++ b/LaSSI/DetailsLayout.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Eto.Forms;
 
 namespace LaSSI
@@ -13,6 +14,7 @@ namespace LaSSI
 
       }
       public State Status { get; set; }
+      public List<CollectionChange> Changes = new();
       public DetailsLayout()
       {
          ID = "DetailsLayout";

--- a/LaSSI/InventoryGridItem.cs
+++ b/LaSSI/InventoryGridItem.cs
@@ -1,4 +1,5 @@
 ﻿using Eto.Forms;
+using System.Collections;
 using System.Collections.ObjectModel;
 
 namespace LaSSI
@@ -23,6 +24,10 @@ namespace LaSSI
       public override string ToString()
       {
          return this.Name;
+      }
+      public DictionaryEntry ToDictionaryEntry()
+      {
+         return new DictionaryEntry(this.Name, this.Count);
       }
    }
 }

--- a/LaSSI/ListBuilder.cs
+++ b/LaSSI/ListBuilder.cs
@@ -23,7 +23,9 @@ namespace LaSSI
       private List<Button> Buttons { get; set; } = new List<Button>();
       private int MaxHeight { get; set; } = 0;
       private int WidthMultiplicand { get; } = 8;
-      #endregion
+      public event EventHandler? RightGridUpdated;
+      #endregion class variables
+
 
       #region constructors
       public ListBuilder(ObservableCollection<InventoryGridItem> leftList, ObservableCollection<InventoryGridItem> rightList)
@@ -49,7 +51,7 @@ namespace LaSSI
 
          Content = CreateMainLayout();
       }
-      #endregion
+      #endregion constructors
 
       #region initializers
       private DynamicLayout CreateMainLayout()
@@ -86,7 +88,7 @@ namespace LaSSI
          if (LeftHeaders != null && LeftHeaders.Count > 0)
          {
             int maxheaderlength = LeftHeaders.OrderByDescending(x => x.Length).First().Length;
-            if(maxheaderlength > widthMultiplier)
+            if (maxheaderlength > widthMultiplier)
             {
                widthMultiplier = maxheaderlength;
             }
@@ -107,12 +109,12 @@ namespace LaSSI
                      Binding = Binding.Property((InventoryGridItem i) => i.Name)
                   },
                   Sortable = true,
-                  
+
                }
             },
          };
          LeftGridView.Shown += LeftGridView_Shown;
-         LeftList.CollectionChanged += LeftList_CollectionChanged;
+         //LeftList.CollectionChanged += LeftList_CollectionChanged;
          if (LeftHeaders != null && LeftHeaders.Count > 0)
          {
             for (int i = 0; i < LeftHeaders.Count; i++)
@@ -170,6 +172,7 @@ namespace LaSSI
          };
          RightGridView.Shown += RightGridView_Shown;
          RightList.CollectionChanged += RightList_CollectionChanged;
+         RightGridView.CellEdited += RightListBox_CellEdited;
          if (RightHeaders != null)
          {
             for (int i = 0; i < RightHeaders.Count; i++)
@@ -178,7 +181,6 @@ namespace LaSSI
             }
          }
          //RightListBox.ColumnWidthChanged += RightListBox_ColumnWidthChanged;
-         RightGridView.CellEdited += RightListBox_CellEdited;
          return RightGridView;
       }
       private StackLayout CreateButtonsLayout()
@@ -226,7 +228,7 @@ namespace LaSSI
          Buttons.Add(MoveLeft);
          Buttons.Add(MoveLeftAll);
       }
-      #endregion
+      #endregion initializers
       #region utility
       private static int GetAlphabeticalPosition(ObservableCollection<InventoryGridItem> collection, string value)
       {
@@ -285,7 +287,7 @@ namespace LaSSI
       }
       private int LongestEntryLength(ObservableCollection<InventoryGridItem> items)
       {
-         if(items.Count > 0)
+         if (items.Count > 0)
          {
             return items.OrderByDescending((InventoryGridItem x) => x.Name.Length).First().Name.Length;
          }
@@ -301,7 +303,15 @@ namespace LaSSI
          }
          if (longest > WidthMultiplier) WidthMultiplier = longest;
       }
-      #endregion
+      public static bool IsGridModified(Dictionary<string, string> initialData, Dictionary<string, string> currentData)
+      {
+         return !(initialData.Count == currentData.Count && !initialData.Except(currentData).Any());
+      }
+      public ObservableCollection<InventoryGridItem> GetRightList()
+      {
+         return RightList;
+      }
+      #endregion utility
 
       #region event handlers
       private void MoveRightAll_Click(object? sender, EventArgs e)
@@ -381,27 +391,29 @@ namespace LaSSI
       }
       private void LeftList_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
       {
-         if (e != null && e.NewItems != null)
-         {
-            UpdateColumnWidthMultiplicand(e.NewItems.GetEnumerator());
-         }
-         int proposedWidth = WidthMultiplicand * WidthMultiplier;
-         if (proposedWidth > LeftGridView.Columns[0].Width) LeftGridView.Columns[0].Width = proposedWidth;
+         //if (e != null && e.NewItems != null) // is any of this actually necessary at this point?
+         //{
+         //   UpdateColumnWidthMultiplicand(e.NewItems.GetEnumerator());
+         //}
+         //int proposedWidth = WidthMultiplicand * WidthMultiplier;
+         //if (proposedWidth > LeftGridView.Columns[0].Width) LeftGridView.Columns[0].Width = proposedWidth;
       }
       private void RightList_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
       {
-         if (e != null && e.NewItems != null)
-         {
-            UpdateColumnWidthMultiplicand(e.NewItems.GetEnumerator());
-         }
-         int proposedWidth = WidthMultiplicand * WidthMultiplier;
-         if (proposedWidth > RightGridView.Columns[0].Width) RightGridView.Columns[0].Width = proposedWidth;
+         //if (e != null && e.NewItems != null) // is any of this actually necessary at this point?
+         //{
+         //   UpdateColumnWidthMultiplicand(e.NewItems.GetEnumerator());
+         //}
+         //int proposedWidth = WidthMultiplicand * WidthMultiplier;
+         //if (proposedWidth > RightGridView.Columns[0].Width) RightGridView.Columns[0].Width = proposedWidth;
+         //Dictionary<string, string> currentValues = (Dictionary<string, string>)RightList;
+         RightGridUpdated?.Invoke(RightList, null);
       }
       private static void RightListBox_CellEdited(object? sender, GridViewCellEventArgs e) //todo: finish this
       {
          Debug.WriteLine("hello!");
       }
-      #endregion
-      
+      #endregion event handlers
+
    }
 }

--- a/LaSSI/Oncler.cs
+++ b/LaSSI/Oncler.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections;
+
+namespace LaSSI
+{
+   public class Oncler
+   {
+      public string Key { get; set; }
+      public string? Value { get; set; }
+
+      public Oncler()
+      {
+         Key = string.Empty;
+         Value = string.Empty;
+      }
+      public Oncler(string k)
+      {
+         Key = k;
+         Value = string.Empty;
+      }
+      public Oncler(string k, string v)
+      {
+         Key = k;
+         Value = v;
+      }
+      public Oncler(DictionaryEntry entry)
+      {
+         Key = entry.Key.ToString()!;
+         if (entry.Value is not null)
+         {
+            Value = entry.Value.ToString()!;
+         }
+         else
+         {
+            Value = string.Empty;
+         }
+      }
+      public DictionaryEntry ToDictionaryEntry()
+      {
+         return new DictionaryEntry(Key, Value);
+      }
+   }
+}
+

--- a/LaSSI/RadioInputDialog.cs
+++ b/LaSSI/RadioInputDialog.cs
@@ -1,0 +1,86 @@
+﻿using Eto.Forms;
+using Eto.Drawing;
+using System;
+
+namespace LaSSI
+{
+   public class RadioInputDialog : Dialog
+   {
+
+      public RadioInputDialog()
+      {
+
+      }
+      //public RadioInputDialog(string title)
+      //{
+      //   CommonSetup(title);
+      //}
+      public RadioInputDialog(string title, string[] options)
+      {
+         //TextBox.PlaceholderText = hint;
+         Options = options;
+         CommonSetup(title);
+      }
+      public DialogResult GetDialogResult()
+      {
+         return Result;
+      }
+      private void CommonSetup(string title)
+      {
+         Title = title;
+         DynamicLayout layout = new()
+         {
+            Padding = new Padding(5, 5),
+            Spacing = new Size(0, 5)
+         };
+         Content = layout;
+
+         buttonList.Orientation = Orientation.Vertical;
+         buttonList.Spacing = new Size(0, 5);
+         foreach (var opt in Options)
+         {
+            buttonList.Items.Add(opt);
+         }
+         layout.AddCentered(buttonList);
+         buttonList.SelectedIndex = 0;
+         layout.AddCentered(ButtonsLayout());
+      }
+
+      public int GetSelectedIndex()
+      {
+         return buttonList.SelectedIndex;
+      }
+
+      private StackLayout ButtonsLayout()
+      {
+         Button ok = new(OK_clicked)
+         {
+            Text = "OK",
+         };
+         OK = ok;
+         this.DefaultButton = ok; // this seems bad but I'm not fixing it now
+         Button cancel = new() { Text = "Cancel" };
+         cancel.Click += delegate
+         {
+            Result = DialogResult.Cancel;
+            Close();
+         };
+         this.AbortButton = cancel;
+         return new StackLayout(ok, cancel) { Orientation = Orientation.Horizontal, Spacing = 5 };
+      }
+
+      private void OK_clicked(object? sender, EventArgs e)
+      {
+         Result = DialogResult.Ok;
+         Close();
+      }
+
+      //public string Hint { get; set; } = string.Empty;
+      //private readonly TextBox TextBox = new();
+      private DialogResult Result = DialogResult.None;
+      private string[] Options = new string[0];
+      private Button? OK;
+      RadioButtonList buttonList = new RadioButtonList();
+   }
+}
+

--- a/LaSSI/TextInputDialog.cs
+++ b/LaSSI/TextInputDialog.cs
@@ -1,0 +1,87 @@
+﻿using Eto.Forms;
+using Eto.Drawing;
+using System;
+
+namespace LaSSI
+{
+   public class TextInputDialog : Dialog
+   {
+
+      public TextInputDialog()
+      {
+
+      }
+      public TextInputDialog(string title)
+      {
+         CommonSetup(title);
+      }
+      public TextInputDialog(string title, string hint)
+      {
+         TextBox.PlaceholderText = hint;
+         CommonSetup(title);
+      }
+      public string GetInput()
+      {
+         return TextBox.Text;
+      }
+      public DialogResult GetDialogResult()
+      {
+         return Result;
+      }
+      private void CommonSetup(string title)
+      {
+         Title = title;
+         DynamicLayout layout = new()
+         {
+            Padding = new Padding(5, 5)
+         };
+         Content = layout;
+         layout.BeginCentered(new Padding(5, 5));
+         layout.Add(TextBox);
+         layout.EndCentered();
+         layout.BeginCentered(new Padding(5, 5));
+         layout.AddCentered(ButtonsLayout());
+         layout.EndCentered();
+         TextBox.TextChanged += TextBox_TextChanged;
+      }
+
+      private void TextBox_TextChanged(object? sender, EventArgs e)
+      {
+         if (sender is not null and TextBox t && OK is not null)
+         {
+            OK.Enabled = t.Text.Trim().Length > 0;
+         }
+      }
+
+      private StackLayout ButtonsLayout()
+      {
+         Button ok = new(OK_clicked)
+         {
+            Text = "OK",
+            Enabled = false,
+         };
+         OK = ok;
+         this.DefaultButton = ok; // this seems bad but I'm not fixing it now
+         Button cancel = new() { Text = "Cancel" };
+         cancel.Click += delegate
+         {
+            Result = DialogResult.Cancel;
+            Close();
+         };
+         this.AbortButton = cancel;
+         return new StackLayout(ok, cancel) { Orientation = Orientation.Horizontal, Spacing = 5 };
+      }
+
+      private void OK_clicked(object? sender, EventArgs e)
+      {
+         Result = DialogResult.Ok;
+         Close();
+      }
+
+      public string Hint { get; set; } = string.Empty;
+      private readonly TextBox TextBox = new();
+      private DialogResult Result = DialogResult.None;
+      private Button? OK;
+   }
+}
+


### PR DESCRIPTION
Added a ton of garbage related to tracking changes in the details panels. All of it needs to be revised; some needs to be rewritten or just ripped out.

Finished Apply; SaveAs now prompts the user to apply all unapplied changes.

Added the Tools menu with one tool so far: CLEAN DERELICTS.

	new file:   CollectionChange.cs
	modified:   DataPanel.cs
	modified:   DetailsLayout.cs
	modified:   InventoryGridItem.cs
	modified:   ListBuilder.cs
	modified:   MainForm.eto.cs
	new file:   Oncler.cs
	new file:   RadioInputDialog.cs
	new file:   TextInputDialog.cs