### PR TITLE
Issue #43

### DIFF
--- a/LaSSI/CustomCommands.cs
+++ b/LaSSI/CustomCommands.cs
@@ -1,5 +1,4 @@
-﻿using Eto;
-using Eto.Forms;
+﻿using Eto.Forms;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -462,11 +461,12 @@ namespace LaSSI
       {
          PrefsDialog f = new PrefsDialog(MainForm.prefs);
          f.ShowModal(MainForm);
+         MainForm.DataPanel.RefreshTree(); // todo: this should only trigger if the user made a change that requires it
       }
       private void QuitCommand_Executed(object? sender, EventArgs e)
       {
-         //   if ((EtoEnvironment.Platform.IsMac && ReadyForQuit()) || !EtoEnvironment.Platform.IsMac)
-         //   {
+         //if ((EtoEnvironment.Platform.IsMac && ReadyForQuit()) || !EtoEnvironment.Platform.IsMac)
+         //{
          Application.Instance.Quit();
          //}
       }

--- a/LaSSI/MainForm.eto.cs
+++ b/LaSSI/MainForm.eto.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 
 namespace LaSSI
 {
@@ -38,9 +37,10 @@ namespace LaSSI
          Size = new Size(1024, 600);
          Location = AdjustForFormSize(GetScreenCenter(), Size);
          Padding = 10;
-         DataPanel = new DataPanel(InventoryMasterList, Width);
+         DataPanel = new DataPanel(this, InventoryMasterList, Width);
          CustomCommands = new CustomCommands(this);
          prefs = new Prefs(this);
+         //prefs.PrefsDialog.UiRefreshRequired += PrefsDialog_UiRefreshRequired;
          // create menu
          fileMenu = new() { Text = "&File" };
          fileMenu.Items.AddRange(CustomCommands.FileCommands);
@@ -73,6 +73,11 @@ namespace LaSSI
          PlatformSpecificNonsense();
          Startup();
       }
+
+      //private void PrefsDialog_UiRefreshRequired(object? sender, EventArgs e)
+      //{
+      //   DataPanel.RefreshTree();
+      //}
 
       private void MainForm_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
       {
@@ -174,7 +179,7 @@ namespace LaSSI
       }
       internal void UpdateUiAfterLoad()
       {
-         UpdateTextbox("saveFileTextbox", TrimFilePathForSafety(saveFilePath));
+         _ = UpdateTextbox("saveFileTextbox", TrimFilePathForSafety(saveFilePath));
          DataPanel.Rebuild(saveFile.Root);
          LoadingBar.Visible = false;
       }


### PR DESCRIPTION
Dec 20-31, the tree turns red and green; Jan 1-3, the tree turns brown; then it’s back to black. This can be turned off in the Prefs menu.

Apparently now we don’t need to get ready for quit as a separate step on Mac either. I don’t know why.

	modified:   CustomCommands.cs
	modified:   DataPanel.cs
	modified:   MainForm.eto.cs
	modified:   Prefs.cs