### PR TITLE
Change colour of text on tree

### DIFF
--- a/LaSSI/DataPanel.cs
+++ b/LaSSI/DataPanel.cs
@@ -1534,7 +1534,6 @@ namespace LaSSI
          {
             if (mainForm is not null)
             {
-               e.ForegroundColor = Colors.White;
                if (mainForm.prefs.holidayFun.value is not null and yesno holidayfun && holidayfun == yesno.yes)
                {
                   var today = DateTime.Today;
@@ -1553,7 +1552,7 @@ namespace LaSSI
                   }
                   else if (today >= NewYearDay && today < NewYearDay.AddDays(3))
                   {
-                     e.ForegroundColor = e.Row % 2 == 0 ? Colors.Cyan : Colors.Pink;
+                     e.ForegroundColor = Colors.HotPink;
                   }
                }
             }

--- a/LaSSI/DataPanel.cs
+++ b/LaSSI/DataPanel.cs
@@ -1534,7 +1534,7 @@ namespace LaSSI
          {
             if (mainForm is not null)
             {
-               e.ForegroundColor = Colors.Black;
+               e.ForegroundColor = Colors.White;
                if (mainForm.prefs.holidayFun.value is not null and yesno holidayfun && holidayfun == yesno.yes)
                {
                   var today = DateTime.Today;
@@ -1553,7 +1553,7 @@ namespace LaSSI
                   }
                   else if (today >= NewYearDay && today < NewYearDay.AddDays(3))
                   {
-                     e.ForegroundColor = Colors.SaddleBrown;
+                     e.ForegroundColor = e.Row % 2 == 0 ? Colors.Cyan : Colors.Pink;
                   }
                }
             }


### PR DESCRIPTION
The black text (and brown text during new years) is really hard to read on such a dark background - especially for visually impaired users.

This makes the colours much lighter in hopes that it is easier to see.