### PR TITLE
Fix issues with Linux artifacts by moving to automated releases

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,13 +43,20 @@ jobs:
       run: |
         pushd ${{ env.Wap_Project_Directory }}/output/
         chmod +x LaSSI
-        zip LaSSI.zip LaSSI
+        zip LaSSI.linux_x64.v0.${{ github.event.inputs.version }}.zip LaSSI
         ls -al .
         popd
+        mv ${{ env.Wap_Project_Directory }}/output/LaSSI.linux_x64.v0.${{ github.event.inputs.version }}.zip .
       shell: bash
 
     - name: Upload build artifact - Linux
-      uses: actions/upload-artifact@v3
+      uses: ncipollo/release-action@main
       with:
-        name: "LaSSI.linux_x64.v0.${{ github.event.inputs.version }}"
-        path: ${{ env.Wap_Project_Directory }}/output/LaSSI.zip
+        allowUpdates: true
+        updateOnlyUnreleased: true
+        artifactErrorsFailBuild: true
+        draft: true
+        prerelease: false
+        commit: ${{ github.ref_name }}
+        tag: 'v0.${{ github.event.inputs.version }}'
+        artifacts: 'LaSSI.linux_x64.v0.${{ github.event.inputs.version }}.zip'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,6 +13,9 @@ jobs:
         configuration: [Release]
     runs-on: ubuntu-latest  # For a list of available runner types, refer to https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
+    permissions:
+         contents: write
+
     env:
       Solution_Name: LaSSI.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
       Wap_Project_Directory: LaSSI    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.

--- a/.github/workflows/mac-signing.yml
+++ b/.github/workflows/mac-signing.yml
@@ -60,10 +60,17 @@ jobs:
       run: |
         chmod -R +x ${{ env.Wap_Project_Directory }}/output/LaSSI.app
         ls -al ${{ env.Wap_Project_Directory }}/output/LaSSI.app
+        zip LaSSI.macx64.v0.${{ github.event.inputs.version }}.zip LaSSI
       shell: bash
 
     - name: Upload build artifact - Mac
-      uses: actions/upload-artifact@v3
+      uses: ncipollo/release-action@main
       with:
-        name: "LaSSI.macx64.v0.${{ github.event.inputs.version }}"
-        path: ${{ env.Wap_Project_Directory }}/output/LaSSI.dmg
+        allowUpdates: true
+        updateOnlyUnreleased: true
+        artifactErrorsFailBuild: true
+        draft: true
+        prerelease: false
+        commit: ${{ github.ref_name }}
+        tag: 'v0.${{ github.event.inputs.version }}'
+        artifacts: 'LaSSI.macx64.v0.${{ github.event.inputs.version }}.zip'

--- a/.github/workflows/mac-signing.yml
+++ b/.github/workflows/mac-signing.yml
@@ -20,6 +20,9 @@ jobs:
         configuration: [Release]
     runs-on: macos-latest  # For a list of available runner types, refer to https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
+    permissions:
+         contents: write
+
     env:
       Solution_Name: LaSSI.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
       Wap_Project_Directory: LaSSI    # Replace with the Wap project directory relative to the solution, i.e. MyWpfApp.Package.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,6 +59,9 @@ jobs:
     runs-on: windows-latest  # For a list of available runner types, refer to
                              # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
+    permissions:
+         contents: write
+
     env:
       Solution_Name: LaSSI.sln                         # Replace with your solution name, i.e. MyWpfApp.sln.
      # Test_Project_Path: AzureFirewallCalculator.Tests/AzureFirewallCalculator.Tests.csproj                # Replace with the path to your test project, i.e. MyWpfApp.Tests\MyWpfApp.Tests.csproj.

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,16 +98,17 @@ jobs:
       run: |
         ${{ env.Publish_Script }} '${{ github.event.inputs.version }}'
 
-    # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
-    - name: Upload build artifact - Win
-      uses: actions/upload-artifact@v3
+    - name: Package Files
+      run: powershell Compress-Archive -Path '${{ env.Wap_Project_Directory }}\output\publish\*' -DestinationPath 'LaSSI.win64.v0.${{ github.event.inputs.version }}.zip' -Force
+
+    - name: Upload build artifact - Windows
+      uses: ncipollo/release-action@main
       with:
-        name: "LaSSI.win64.v0.${{ github.event.inputs.version }}"
-        path: ${{ env.Wap_Project_Directory }}\output\publish
-        
-    # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
-    - name: Upload build artifact - Linux
-      uses: actions/upload-artifact@v3
-      with:
-        name: "LaSSI.Linux-x64.v0.${{ github.event.inputs.version }}"
-        path: ${{ env.Wap_Project_Directory }}\output\linux-x64
+        allowUpdates: true
+        updateOnlyUnreleased: true
+        artifactErrorsFailBuild: true
+        draft: true
+        prerelease: false
+        commit: ${{ github.ref_name }}
+        tag: 'v0.${{ github.event.inputs.version }}'
+        artifacts: 'LaSSI.win64.v0.${{ github.event.inputs.version }}.zip'


### PR DESCRIPTION
I thought about this a bit and am proposing a change to how I think you're doing releases. The problem with the Linux builds not keeping the +x bit is that the upload-artifact action doesn't support saving permissions. A solution that I think might work well is to move to using ncipollo/release-action instead.

What you would do when you're ready to publish a release is create a draft release with an associated tag for the version number (v0.2.9.3, for example). Once it's saved, you run your workflows and they will automatically upload the artifacts as release builds to that draft release. You can then review everything, set your title and description and make the release public.

This PR does that, so let me know your thoughts.